### PR TITLE
Add grunt serve script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "grunt",
     "build": "grunt build",
     "deploy": "grunt deploy",
+    "serve": "grunt serve",
     "watch": "grunt browserSync"
   },
   "browserify": {
@@ -61,5 +62,8 @@
     "lodash": "^4.17.4",
     "matchdep": "^1.0.1",
     "wcag": "^0.3.0"
+  },
+  "dependencies": {
+    "grunt-serve": "^0.1.6"
   }
 }


### PR DESCRIPTION
Added dependency of grunt-serve and script "serve" with command "grunt
serve", in order to get a localhost server up and running without using
IntelliJ "open in browser" menu option.

**Run server:**

`npm run serve`

The server runs on port 9000.