### PR TITLE
Create settings pages for webauthn security key administration

### DIFF
--- a/build/demo/update-settings/index.html
+++ b/build/demo/update-settings/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/build/demo/webauthn/MinProfil-MinID-innstillinger-1.html
+++ b/build/demo/webauthn/MinProfil-MinID-innstillinger-1.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html dir="ltr" lang='en'>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title>[BUILD] PAGE TITLE</title>
+
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel="stylesheet" href="../../fonts/open-sans/open-sans.css">
+    <link rel="stylesheet" href="../../font-awesome/css/font-awesome.min.css">
+
+    <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+
+    <link type="text/css" rel="stylesheet" href="../../css/style.css" />
+
+</head>
+
+<body>
+    <!--[if lt IE 11]>
+<p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+<![endif]-->
+
+    <!-- SECTION: HEADER -->
+
+    <header class='h-Main'>
+
+        <div class='h-Main_Content'>
+            <a href="" class="h_Main_Content_Link"><span class="fa fa-angle-left fa-lg" aria-hidden="true"></span><span>Tilbake</span></a>
+
+            <!-- NOTE: placholder class must be present, even if it has no content -->
+            <div class="h-Main_Content_Placeholder">
+                <!-- NOTE: Present on pages with service provider name and logo. Visible on mobile sreens only. -->
+                <span class="h-Main_Content_Provider">Leikanger kommune</span>
+            </div>
+
+            <a href='' role='button' class='h-Menu_Trigger-mobile'><span class="fa fa-bars"></span></a>
+            <div class='h-Menu_Container' id='js-menues'>
+                <nav class='h-Menu'>
+                    <a href='' role='button' aria-haspopup="true" aria-expanded="false" class='h-Menu_Trigger'><span>Kontaktdetaljer</span><span class='fa fa-angle-down fa-lg' aria-hidden="true"></span></a>
+                    <ul>
+                        <li><a href="" class="h-Main_Menu_Element js-last"><span>Endre</span></a></li>
+                    </ul>
+                </nav>
+
+            </div>
+
+        </div>
+    </header>
+
+    <!-- /SECTION: HEADER -->
+
+
+    <main>
+
+        <section class='Box'>
+            <!-- NOTE: provider is added twice: above box title (this one) and below box.
+The one above title is displayed on desktop only. the one below on mobile only. -->
+            <div class='Box_Section Box_Section-ServiceProvider'>
+                <div class='Box_Section_Title'>Leikanger kommune</div>
+                <img src='../../images/nav-logo.gif' alt='tjenestetilbyders logo' />
+            </div>
+            <div class='Box_header'>
+                <h1 class='Box_header-title with-logo logo-eid-gray'>Settings</h1>
+                <div class='Box_header-provider'><img src='../../images/svg/minid-m-kant.svg' alt='MinID logo' /></div>
+            </div>
+
+            <div class='Box_main'>
+
+
+                <!-- Form -->
+                <form action='#'>
+                    <div class='fm-Fields'>
+
+                        <!-- When fm-Field gets class .error then input and span.message change their look and present the error message -->
+                        <div class='fm-Field'>
+                            <span class='label'>Din påloggings-id</span>
+                            <div class='with-icon'>
+                                <span class='text'>min bruker-id</span>
+                                <button>
+      <span class='visuallyHidden'>Klikk her for å endre din bruker</span>
+      <span class='fa fa-pencil'></span>
+    </button>
+                            </div>
+                        </div>
+                        <!-- When fm-Field gets class .error then input and span.message change their look and present the error message -->
+                        <div class='fm-Field'>
+                            <span class='label'>Ditt passord</span>
+                            <div class='with-icon'>
+                                <span class='text'>**********</span>
+                                <button>
+      <span class='visuallyHidden'>Klikk her for å endre passordet ditt</span>
+      <span class='fa fa-pencil'></span>
+    </button>
+                            </div>
+                        </div>
+
+                    </div>
+
+                </form>
+            </div>
+
+            <div class='Box_footer'>
+                <div class='Box_footer-links'>
+                    <!-- <ul> -->
+                    <!-- <li><a href='#'><span>Slik skaffer du elektronisk ID</span></a></li> -->
+                    <!-- <li><a href='#'><span>Menu 2</span></a></li> -->
+                    <!-- </ul> -->
+                </div>
+
+                <!-- <div class='Box_footer-help'>
+  <a href='#'><span class='fa fa-question-circle'></span><span class='visuallyHidden'>Help</span></a>
+</div> -->
+            </div>
+        </section>
+        <!-- NOTE: provider is added twice: above box title and below box (this one).
+  The one above title is displayed on desktop only. the one below on mobile only. -->
+        <div class='mi-Provider'><img src='../../images/nav-logo.gif' alt='Nav logo' /></div>
+
+    </main>
+    <!-- /build -->
+
+    <!-- SECTION: FOOTER -->
+
+    <footer class="f-Main">
+        <div class='f-Main_Content'>
+            <div class='f-Main_Logo' aria-hidden="true"></div>
+            <div class='f-Main_Info'>
+                <a href="" class='f-Main_Link'><span>Kontaktskjema</span></a>
+                <a href="tel:+4780030300" class='f-Main_Link'><span>Tlf: 800 30 300</span></a>
+                <a href="" class='f-Main_Link'><span>Hjelp til innlogging</span></a>
+                <a href="" class='f-Main_Link'><span>Sikkerhet og personvern</span></a>
+                <p>Driftet av Direktoratet for forvaltning og IKT (Difi)</p>
+            </div>
+        </div>
+    </footer>
+
+    <!-- /SECTION: FOOTER -->
+
+    <script type="text/javascript" src="../../js/vendor.min.js"></script>
+    <script type="text/javascript" src="../../js/accordion.js"></script>
+    <script type="text/javascript" src="../../js/country-selector.js"></script>
+    <script type="text/javascript" src="../../js/disabled-links.js"></script>
+    <script type="text/javascript" src="../../js/header.js"></script>
+    <script type="text/javascript" src="../../js/minid-menu.js"></script>
+    <script type="text/javascript" src="../../js/tab.js"></script>
+    <script type="text/javascript" src="../../js/toggleMenues.js"></script>
+    <script type="text/javascript" src="../../js/toggleForm.js"></script>
+    <script type="text/javascript" src="../../js/check-enable-save.js"></script>
+    <script type="text/javascript" src="../../js/radio-enable-save.js"></script>
+</body>
+
+</html>

--- a/build/demo/webauthn/MinProfil-MinID-innstillinger-B.html
+++ b/build/demo/webauthn/MinProfil-MinID-innstillinger-B.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html dir="ltr" lang='en'>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title>[BUILD] PAGE TITLE</title>
+
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel="stylesheet" href="../../fonts/open-sans/open-sans.css">
+    <link rel="stylesheet" href="../../font-awesome/css/font-awesome.min.css">
+
+    <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+
+    <link type="text/css" rel="stylesheet" href="../../css/style.css" />
+
+</head>
+<!-- use class .popup to hiden header and footer, or use .popup .with-footer to keep footer -->
+
+<body class='hide-mobileMenu popup'>
+    <!--[if lt IE 11]>
+<p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+<![endif]-->
+
+    <!-- SECTION: HEADER -->
+
+    <header class='h-Main'>
+
+        <div class='h-Main_Content'>
+            <a href="" class="h_Main_Content_Link"><span class="fa fa-angle-left fa-lg" aria-hidden="true"></span><span>Tilbake</span></a>
+
+            <!-- NOTE: placholder class must be present, even if it has no content -->
+            <div class="h-Main_Content_Placeholder">
+                <!-- NOTE: Present on pages with service provider name and logo. Visible on mobile sreens only. -->
+                <span class="h-Main_Content_Provider">Leikanger kommune</span>
+            </div>
+
+            <a href='' role='button' class='h-Menu_Trigger-mobile'><span class="fa fa-bars"></span></a>
+            <div class='h-Menu_Container' id='js-menues'>
+                <nav class='h-Menu'>
+                    <a href='' role='button' aria-haspopup="true" aria-expanded="false" class='h-Menu_Trigger'><span>Kontaktdetaljer</span><span class='fa fa-angle-down fa-lg' aria-hidden="true"></span></a>
+                    <ul>
+                        <li><a href="" class="h-Main_Menu_Element js-last"><span>Endre</span></a></li>
+                    </ul>
+                </nav>
+
+            </div>
+
+        </div>
+    </header>
+
+    <!-- /SECTION: HEADER -->
+
+
+    <main>
+
+        <section class='Box'>
+            <div class='Box_header'>
+                <h1 class='Box_header-title with-close-button'>Select preferred login</h1>
+                <span class='Box_header-close'>
+    <a href='#'>
+      <span class='fa fa-close'>
+        <span class='visuallyHidden'>Close window</span>
+                </span>
+                </a>
+                </span>
+            </div>
+
+            <div class='Box_main'>
+
+
+                <!-- Form -->
+                <form action='#'>
+                    <div class='fm-Fields with-Link'>
+
+                        <div class='fm-RadioButtons'>
+                            <input id='letter' type='radio' name="login-preference" checked='checked' value="letter" />
+                            <label for='letter'>Code from pin letter</label>
+                            <input id='sms' type='radio' name="login-preference" value="sms" />
+                            <label for='sms' class=''>Code from SMS (93282061)</label>
+                        </div>
+
+                        <div class='fm-form_link with-Link'>
+                            <a href=''><span>Change mobile phone number</span></a>
+                        </div>
+
+                    </div>
+
+                    <!-- Controls placeholder with two buttons -->
+                    <div class='fm-Controls with-Normal with-Action'>
+                        <button class='btn btn-Action' type='submit'><span>Save</span></button>
+                        <button class='btn btn-Normal'><span>Cancel</span></button>
+                    </div>
+                    <!-- //Controls placeholder with two buttons -->
+
+                </form>
+            </div>
+
+        </section>
+
+    </main>
+    <!-- /build -->
+
+    <!-- SECTION: FOOTER -->
+
+    <footer class="f-Main">
+        <div class='f-Main_Content'>
+            <div class='f-Main_Logo' aria-hidden="true"></div>
+            <div class='f-Main_Info'>
+                <a href="" class='f-Main_Link'><span>Kontaktskjema</span></a>
+                <a href="tel:+4780030300" class='f-Main_Link'><span>Tlf: 800 30 300</span></a>
+                <a href="" class='f-Main_Link'><span>Hjelp til innlogging</span></a>
+                <a href="" class='f-Main_Link'><span>Sikkerhet og personvern</span></a>
+                <p>Driftet av Direktoratet for forvaltning og IKT (Difi)</p>
+            </div>
+        </div>
+    </footer>
+
+    <!-- /SECTION: FOOTER -->
+
+    <script type="text/javascript" src="../../js/vendor.min.js"></script>
+    <script type="text/javascript" src="../../js/accordion.js"></script>
+    <script type="text/javascript" src="../../js/country-selector.js"></script>
+    <script type="text/javascript" src="../../js/disabled-links.js"></script>
+    <script type="text/javascript" src="../../js/header.js"></script>
+    <script type="text/javascript" src="../../js/minid-menu.js"></script>
+    <script type="text/javascript" src="../../js/tab.js"></script>
+    <script type="text/javascript" src="../../js/toggleMenues.js"></script>
+    <script type="text/javascript" src="../../js/toggleForm.js"></script>
+    <script type="text/javascript" src="../../js/check-enable-save.js"></script>
+    <script type="text/javascript" src="../../js/radio-enable-save.js"></script>
+</body>
+
+</html>

--- a/build/demo/webauthn/MinProfil-MinID-innstillinger-C.html
+++ b/build/demo/webauthn/MinProfil-MinID-innstillinger-C.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html dir="ltr" lang='en'>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title>[BUILD] PAGE TITLE</title>
+
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel="stylesheet" href="../../fonts/open-sans/open-sans.css">
+    <link rel="stylesheet" href="../../font-awesome/css/font-awesome.min.css">
+
+    <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+
+    <link type="text/css" rel="stylesheet" href="../../css/style.css" />
+
+</head>
+<!-- use class .popup to hiden header and footer, or use .popup .with-footer to keep footer -->
+
+<body class='hide-mobileMenu popup'>
+    <!--[if lt IE 11]>
+<p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+<![endif]-->
+
+    <!-- SECTION: HEADER -->
+
+    <header class='h-Main'>
+
+        <div class='h-Main_Content'>
+            <a href="" class="h_Main_Content_Link"><span class="fa fa-angle-left fa-lg" aria-hidden="true"></span><span>Tilbake</span></a>
+
+            <!-- NOTE: placholder class must be present, even if it has no content -->
+            <div class="h-Main_Content_Placeholder">
+                <!-- NOTE: Present on pages with service provider name and logo. Visible on mobile sreens only. -->
+                <span class="h-Main_Content_Provider">Leikanger kommune</span>
+            </div>
+
+            <a href='' role='button' class='h-Menu_Trigger-mobile'><span class="fa fa-bars"></span></a>
+            <div class='h-Menu_Container' id='js-menues'>
+                <nav class='h-Menu'>
+                    <a href='' role='button' aria-haspopup="true" aria-expanded="false" class='h-Menu_Trigger'><span>Kontaktdetaljer</span><span class='fa fa-angle-down fa-lg' aria-hidden="true"></span></a>
+                    <ul>
+                        <li><a href="" class="h-Main_Menu_Element js-last"><span>Endre</span></a></li>
+                    </ul>
+                </nav>
+
+            </div>
+
+        </div>
+    </header>
+
+    <!-- /SECTION: HEADER -->
+
+
+    <main>
+
+        <section class='Box'>
+            <div class='Box_header'>
+                <h1 class='Box_header-title with-close-button'>Change password</h1>
+                <span class='Box_header-close'>
+    <a href='#'>
+      <span class='fa fa-close'>
+        <span class='visuallyHidden'>Lukk dette vinduet</span>
+                </span>
+                </a>
+                </span>
+            </div>
+
+            <div class='Box_main'>
+
+                <!-- Form -->
+                <form action='#'>
+                    <div class='fm-Fields'>
+                        <!-- When fm-Field gets class .error then input and span.message change their look and present the error message -->
+                        <div class='fm-Field'>
+                            <label for='password-old'>Current password</label>
+                            <input id='password-old' type='password' placeholder='Current password' />
+                        </div>
+                        <span class='fm-Message'>Passwords cannot be empty</span>
+
+                        <div class='fm-Field'>
+                            <label for='password'>New password</label>
+                            <input id='password' type='password' placeholder='New password' />
+                        </div>
+                        <span class='fm-Message'>Please enter a password</span>
+
+                        <div class='fm-Field'>
+                            <label for='password2'>Re-enter new password</label>
+                            <input id='password2' type='password' placeholder='Re-enter new password' />
+                        </div>
+                        <span class='fm-Message'>Passwords does not match</span>
+                    </div>
+                    <!-- Controls placeholder with two buttons -->
+                    <div class='fm-Controls with-Normal with-Action'>
+                        <button class='btn btn-Action' type='submit'><span>Save</span></button>
+                        <button class='btn btn-Normal'><span>Cancel</span></button>
+                    </div>
+                    <!-- //Controls placeholder with two buttons -->
+                </form>
+                <!-- //Form -->
+            </div>
+        </section>
+
+
+    </main>
+    <!-- /build -->
+
+    <!-- SECTION: FOOTER -->
+
+    <footer class="f-Main">
+        <div class='f-Main_Content'>
+            <div class='f-Main_Logo' aria-hidden="true"></div>
+            <div class='f-Main_Info'>
+                <a href="" class='f-Main_Link'><span>Kontaktskjema</span></a>
+                <a href="tel:+4780030300" class='f-Main_Link'><span>Tlf: 800 30 300</span></a>
+                <a href="" class='f-Main_Link'><span>Hjelp til innlogging</span></a>
+                <a href="" class='f-Main_Link'><span>Sikkerhet og personvern</span></a>
+                <p>Driftet av Direktoratet for forvaltning og IKT (Difi)</p>
+            </div>
+        </div>
+    </footer>
+
+    <!-- /SECTION: FOOTER -->
+
+    <script type="text/javascript" src="../../js/vendor.min.js"></script>
+    <script type="text/javascript" src="../../js/accordion.js"></script>
+    <script type="text/javascript" src="../../js/country-selector.js"></script>
+    <script type="text/javascript" src="../../js/disabled-links.js"></script>
+    <script type="text/javascript" src="../../js/header.js"></script>
+    <script type="text/javascript" src="../../js/minid-menu.js"></script>
+    <script type="text/javascript" src="../../js/tab.js"></script>
+    <script type="text/javascript" src="../../js/toggleMenues.js"></script>
+    <script type="text/javascript" src="../../js/toggleForm.js"></script>
+    <script type="text/javascript" src="../../js/check-enable-save.js"></script>
+    <script type="text/javascript" src="../../js/radio-enable-save.js"></script>
+</body>
+
+</html>

--- a/build/demo/webauthn/MinProfil-MinID-innstillinger-D.html
+++ b/build/demo/webauthn/MinProfil-MinID-innstillinger-D.html
@@ -59,11 +59,11 @@
 
         <section class='Box'>
             <div class='Box_header'>
-                <h1 class='Box_header-title with-close-button'>Select preferred login</h1>
+                <h1 class='Box_header-title with-close-button'>Administrer sikkerhetsnøkkel</h1>
                 <span class='Box_header-close'>
     <a href='#'>
       <span class='fa fa-close'>
-        <span class='visuallyHidden'>Close window</span>
+        <span class='visuallyHidden'>Lukk dette vinduet</span>
                 </span>
                 </a>
                 </span>
@@ -71,41 +71,43 @@
 
             <div class='Box_main'>
 
-
+                <!-- TODO: info -->
+                <!-- TODO: new form -->
                 <!-- Form -->
-                <form action='#'>
-                    <div class='fm-Fields with-Link'>
-
-                        <div class='fm-RadioButtons'>
-                            <input id='letter' type='radio' name="login-preference" checked='checked' value="letter" />
-                            <label for='letter'>Code from pin letter</label>
-                            <input id='sms' type='radio' name="login-preference" value="sms" />
-                            <label for='sms' class=''>Code from SMS (93282061)</label>
-                            <input id='webauthn' type='radio' name="login-preference" value="webauthn" />
-                            <label for='webauthn'>Smart-enhet som sikkerhetsnøkkel</label>
+                <form action='MinProfil-MinID-innstillinger-B.html'>
+                    <div class='fm-Fields'>
+                        <!-- When fm-Field gets class .error then input and span.message change their look and present the error message -->
+                        <div class='fm-Field'>
+                            <label for='security-key-name'>Navn på sikkerhetsnøkkel</label>
+                            <div class='with-icon'>
+                                <input id='security-key-name' type='text' placeholder='Navn på sikkerhetsnøkkel' value="min sikkerhetsnøkkel" />
+                                <button>
+                                    <span class='visuallyHidden'>Klikk her for å endre navn på sikkerhetsnøkkel</span>
+                                    <span class='fa fa-pencil'></span>
+                                </button>
+                            </div>
                         </div>
+                        <span class='fm-Message'>Sikkerhetsnøkkel må ha et navn</span>
 
-                        <div class='fm-form_link with-Link'>
-                            <a href=''><span>Change mobile phone number</span></a>
+                        <div class='fm-Field'>
+                            <label for='security-key-registration-date'>Registrert</label>
+                            <input id='security-key-registration-date' type='text' value="Tue, 03 Jul 2018 10:23:42 GMT" disabled />
                         </div>
-
-                        <div class='fm-form_link with-Link'>
-                            <a href='MinProfil-MinID-innstillinger-D.html'><span>Administrer sikkerhetsnøkkel</span></a>
-                        </div>
-
                     </div>
-
                     <!-- Controls placeholder with two buttons -->
+                    <div class='fm-Controls with-Normal'>
+                        <button class='btn btn-Normal'><span>Fjern sikkerhetsnøkkel</span></button>
+                    </div>
                     <div class='fm-Controls with-Normal with-Action'>
                         <button class='btn btn-Action' type='submit'><span>Save</span></button>
                         <button class='btn btn-Normal'><span>Cancel</span></button>
                     </div>
                     <!-- //Controls placeholder with two buttons -->
-
                 </form>
+                <!-- //Form -->
             </div>
-
         </section>
+
 
     </main>
     <!-- /build -->


### PR DESCRIPTION
Most importantly, created pages MinProfil-MinID-innstillinger-B.html, which links to MinProfil-MinID-innstillinger-D.html that allows the user to administer a registered security key. For the time being, working under the assumption that there can only be one security key.

The administration page allows you to edit the name of the security key, view its time of registration, and remove the security key. Pressing any button returns the user to B.html.