### PR TITLE
Use device removal trigger in settings page

### DIFF
--- a/build/demo/update-settings/MinProfil-MinID-innstillinger-D.html
+++ b/build/demo/update-settings/MinProfil-MinID-innstillinger-D.html
@@ -129,6 +129,7 @@
     <script type="text/javascript" src="../../js/check-enable-save.js"></script>
     <script type="text/javascript" src="../../js/radio-enable-save.js"></script>
     <script type="text/javascript" src="../../js/update-localstorage-fields.js"></script>
+    <script type="text/javascript" src="../../js/localStorage.js"></script>
     <script type="text/javascript" src="../../js/MinProfil-MinID-innstillinger-D.js"></script>
 </body>
 

--- a/build/js/MinProfil-MinID-innstillinger-D.js
+++ b/build/js/MinProfil-MinID-innstillinger-D.js
@@ -42,6 +42,6 @@
     // Actually remove the security key
     // Form is submitted when this function returns
     $("#btn-submit-remove").on("click", function(event) {
-        window.localStorage.setItem("webauthn-device", JSON.stringify({}));
+        $(document).trigger('webauthn:remove-device');
     });
 })();


### PR DESCRIPTION
Updated the callback for removing the security key to use the trigger
defined in localStorage instead of modifying localStorage directly.
Should also make use of events when saving updates, and maybe also when
updating the auth type in B.html. Would require modifying
localStorage.js.