### PR TITLE
Fix 'Avbryt' and 'Tilbake' links for onboarding (#35)

### DIFF
--- a/build/demo/login-with-onboarding-webauthn/MinID-2A.html
+++ b/build/demo/login-with-onboarding-webauthn/MinID-2A.html
@@ -20,7 +20,7 @@
     <!-- SECTION: HEADER -->
     <header class='h-Main'>
         <div class='h-Main_Content'>
-            <a href="../webauthn/index.html" class="h_Main_Content_Link"><span class="fa fa-angle-left fa-lg" aria-hidden="true"></span><span>Tilbake</span></a>
+            <a href="index.html" class="h_Main_Content_Link"><span class="fa fa-angle-left fa-lg" aria-hidden="true"></span><span>Tilbake</span></a>
             <!-- NOTE: placholder class must be present, even if it has no content -->
             <div class="h-Main_Content_Placeholder">
                 <!-- NOTE: Present on pages with service provider name and logo. Visible on mobile sreens only. -->
@@ -107,7 +107,7 @@ The one above title is displayed on desktop only. the one below on mobile only. 
                     <!-- Controls placeholder with two buttons -->
                     <div class='fm-Controls with-Normal with-Action'>
                         <button class='btn btn-Action' type='submit'><span>Neste</span></button>
-                        <button class='btn btn-Normal'><span>Avbryt</span></button>
+                        <button class='btn btn-Normal btn-Abort fully'><span>Avbryt</span></button>
                     </div>
                     <!-- //Controls placeholder with two buttons -->
                 </form>
@@ -156,6 +156,7 @@ The one above title is displayed on desktop only. the one below on mobile only. 
     <script type="text/javascript" src="../../js/toggleForm.js"></script>
     <script type="text/javascript" src="../../js/check-enable-save.js"></script>
     <script type="text/javascript" src="../../js/radio-enable-save.js"></script>
+    <script type="text/javascript" src="../../js/abort-buttons.js"></script>
 </body>
 
 </html>

--- a/build/demo/login-with-onboarding-webauthn/MinID-2C.html
+++ b/build/demo/login-with-onboarding-webauthn/MinID-2C.html
@@ -138,7 +138,7 @@ The one above title is displayed on desktop only. the one below on mobile only. 
                     <div class="fm-Field add-to-list">
                         <div class='fm-Controls with-Normal with-Action'>
                             <button class='btn btn-Action' type='submit'><span>Neste</span></button>
-                            <button class='btn btn-Normal'><span>Avbryt</span></button>
+                            <button class='btn btn-Normal btn-Abort fully'><span>Avbryt</span></button>
                         </div>
                     </div>
                     <!-- //Controls placeholder with two buttons -->
@@ -191,6 +191,7 @@ The one above title is displayed on desktop only. the one below on mobile only. 
     <script type="text/javascript" src="../../js/name-devices.js"></script>
     <script type="text/javascript" src="../../js/addWebauthnDeviceMenu.js"></script>
     <script type="text/javascript" src="../../js/localStorage.js"></script>
+    <script type="text/javascript" src="../../js/abort-buttons.js"></script>
 </body>
 
 </html>

--- a/build/demo/login-with-onboarding-webauthn/MinID-2D.html
+++ b/build/demo/login-with-onboarding-webauthn/MinID-2D.html
@@ -81,7 +81,7 @@ The one above title is displayed on desktop only. the one below on mobile only. 
             <!-- Controls placeholder with two buttons -->
             <div class='fm-Controls with-Normal with-Action'>
                 <button class='btn btn-Action' type='submit'><span>Fortsett til NAV</span></button>
-                <button class='btn btn-Normal'><span>Avbryt</span></button>
+                <button class='btn btn-Normal btn-Abort fully'><span>Avbryt</span></button>
             </div>
             <!-- //Controls placeholder with two buttons -->
             </form>
@@ -121,6 +121,7 @@ The one above title is displayed on desktop only. the one below on mobile only. 
     <script type="text/javascript" src="../../js/toggleForm.js"></script>
     <script type="text/javascript" src="../../js/check-enable-save.js"></script>
     <script type="text/javascript" src="../../js/radio-enable-save.js"></script>
+    <script type="text/javascript" src="../../js/abort-buttons.js"></script>
 </body>
 
 </html>

--- a/build/demo/login-with-onboarding-webauthn/index.html
+++ b/build/demo/login-with-onboarding-webauthn/index.html
@@ -20,7 +20,7 @@
     <!-- SECTION: HEADER -->
     <header class='h-Main'>
         <div class='h-Main_Content'>
-            <a href="" class="h_Main_Content_Link"><span class="fa fa-angle-left fa-lg" aria-hidden="true"></span><span>Tilbake</span></a>
+            <a href="../landing-page/index.html" class="h_Main_Content_Link"><span class="fa fa-angle-left fa-lg" aria-hidden="true"></span><span>Tilbake</span></a>
             <!-- NOTE: placholder class must be present, even if it has no content -->
             <div class="h-Main_Content_Placeholder">
                 <!-- NOTE: Present on pages with service provider name and logo. Visible on mobile sreens only. -->
@@ -113,7 +113,7 @@ The one above title is displayed on desktop only. the one below on mobile only. 
                     <!-- Controls placeholder with two buttons -->
                     <div class='fm-Controls with-Normal with-Action'>
                         <button class='btn btn-Action' type='submit'><span>Neste</span></button>
-                        <button class='btn btn-Normal'><span>Avbryt</span></button>
+                        <button class='btn btn-Normal btn-Abort fully'><span>Avbryt</span></button>
                     </div>
                     <!-- //Controls placeholder with two buttons -->
                 </form>
@@ -150,6 +150,7 @@ The one above title is displayed on desktop only. the one below on mobile only. 
     </footer>
     <!-- /SECTION: FOOTER -->
     <script type="text/javascript" src="../../js/vendor.min.js"></script>
+    <script type="text/javascript" src="../../js/abort-buttons.js"></script>
 </body>
 
 </html>

--- a/build/js/abort-buttons.js
+++ b/build/js/abort-buttons.js
@@ -1,0 +1,11 @@
+(function() {
+    let $ = jQuery.noConflict();
+    $(".btn-Abort.partially").on("click", e => {
+        e.preventDefault();
+        window.location.href = document.referrer;
+    });
+    $(".btn-Abort.fully").on("click", e => {
+        e.preventDefault();
+        window.location.href = "../landing-page/index.html";
+    });
+})();


### PR DESCRIPTION
Added a new JS script "abort-buttons.js", which contains code for "Avbryt" buttons. Give those buttons the class "btn-Abort" and either "fully" or "partially". If fully, redirect to landing page. If partially, redirect to previous page (document.referrer)

**Example:**

```html
<button class="btn btn-Normal btn-Abort fully">Avbryt</button>
```