### PR TITLE
Close #105 - update device name in settings

### DIFF
--- a/build/demo/update-settings/MinProfil-MinID-innstillinger-D.html
+++ b/build/demo/update-settings/MinProfil-MinID-innstillinger-D.html
@@ -129,7 +129,10 @@
                 </div>
                 <div class='fm-Controls with-Normal with-Action'>
                     <button id="btn-submit" class='btn btn-Action' type='submit'>
-                        <span>Tilbake</span>
+                        <span>Lagre</span>
+                    </button>
+                    <button class='btn btn-Normal'>
+                        <span>Avbryt</span>
                     </button>
                     <!-- Submit form with removal option -->
                 </div>

--- a/build/js/MinProfil-MinID-innstillinger-D.js
+++ b/build/js/MinProfil-MinID-innstillinger-D.js
@@ -44,4 +44,11 @@
     $("#btn-submit-remove").on("click", function(event) {
         $(document).trigger('webauthn:remove-device');
     });
+
+    $("#btn-submit").on("click", function(event) {
+        $(document).trigger('webauthn:update-device', {
+            name: $("#security-key-name").val(),
+            date: $("#security-key-registration-date").val()
+        });
+    });
 })();

--- a/build/js/localStorage.js
+++ b/build/js/localStorage.js
@@ -18,6 +18,16 @@ const localStorage = () => {
         console.log('webauthn-device cleared from local storage');
         resetPreferredAuthType();
     });
+    
+    $(document).on('webauthn:update-device', (event, data) => {
+        console.log('webauthn:update-device in localStorage.js');
+        let norm = normalizeWebAuthnDeviceData(data);
+        if (norm.error) {
+            console.log("ERROR updating device: data not in compatible format");
+            console.log("Error message:", error);
+        }
+        window.localStorage.setItem("webauthn-device", JSON.stringify(norm));
+    });
 
     /**
      * Function to be called after the Webauthn device is removed.
@@ -26,6 +36,32 @@ const localStorage = () => {
         window.localStorage.removeItem('auth-type');
     };
 
+    /**
+     * Function normalizing event data.
+     */
+    const normalizeWebAuthnDeviceData = data => {
+        if (!data)
+          return {error: "Device data not found"};
+        if (!data.name)
+          return {error: "Device name not in data"};
+        if (!data.date)
+          return {error: "Device registration date not in data"};
+        let dt = data.date;
+        if (typeof dt === "string") {
+          dt = Date.parse(data.date)
+          if (!dt)
+            return {error: "Device registration date not in valid date format:" +
+                " non-parseable string"};
+        }
+        else if (dt instanceof Date) {
+            dt = dt.getTime();
+        }
+        else if (typeof dt !== "number") {
+            return {error: "Device registration date not in valid date format:" +
+                " not a date string, date object or timestamp"};
+        }
+        return {name: data.name, date: new Date(dt)};
+    };
 };
 
 localStorage();

--- a/build/js/update-localstorage-fields.js
+++ b/build/js/update-localstorage-fields.js
@@ -57,10 +57,21 @@ var getAuthTypeHumanReadable = () => {
     console.log('updateFieldsWithDevice');
     console.log(data);
     if (!data) return;
+    
+    let dt = data.date;
+    if (!dt){
+      console.log("ERROR: data.date not found");
+      return;
+    }
+    if (typeof dt === "string")
+      dt = new Date(Date.parse(dt)); // try to convert the data to a date
+      // NOTE: The above may cause an error. This indicates a programming error.
+      // It should be graciously handled, but let's not worry about it for now.
+    
     $(".securitykey-name").html(data.name);
-    $('.securitykey-time').html(data.date.toISOString());
+    $('.securitykey-time').html(dt.toISOString());
     $("input[type='text'].securitykey-name").val(data.name);
-    $("input[type='text'].securitykey-time").val(data.date.toISOString());
+    $("input[type='text'].securitykey-time").val(dt.toISOString());
   };
   const clearFields = () => {
     console.log('clearFields');
@@ -90,6 +101,13 @@ var getAuthTypeHumanReadable = () => {
     $('#add-webauthn-message').text('Smartenheten er nå fjernet');
     $('#remove-security-key-dialog').hide();
     $('#webauthn-add-device-box').show();
+  });
+  $(document).on('webauthn:update-device', (event, data) => {
+    console.log("webauthn:update-device in update-localstorage-fields.js");
+    updateFieldsWithDevice(event, data);
+  });
+  $(document).on('webauthn:update-auth-type', (event, data) => {
+    // TODO
   });
 
   // update fields initially


### PR DESCRIPTION
Re-added the 'Avbryt'/'Lagre' buttons, and created an onclick listener
for the save button that emits a webauthn:update-device event. Added
event listener in localStorage.js that updates localStorage upon seeing
this event, and an event listener in update-localstorage-fields.js that
updates the fields on the page (not relevant to the settings page,
though).

Updating the device name in settings now works as expected. It's still
not possible to register a device from the page in question.